### PR TITLE
Fix for ignored exceptions 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.coveo</groupId>
     <artifactId>spring-boot-parameter-store-integration</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 
     <name>Spring Boot Parameter Store Integration</name>
     <description>An integration of Amazon Web Services' Systems Manager Parameter Store for Spring Boot's properties injection.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.coveo</groupId>
     <artifactId>spring-boot-parameter-store-integration</artifactId>
-    <version>1.1.0</version>
+    <version>1.0.1</version>
 
     <name>Spring Boot Parameter Store Integration</name>
     <description>An integration of Amazon Web Services' Systems Manager Parameter Store for Spring Boot's properties injection.</description>

--- a/src/main/java/com/coveo/configuration/parameterstore/ParameterStoreSource.java
+++ b/src/main/java/com/coveo/configuration/parameterstore/ParameterStoreSource.java
@@ -3,8 +3,8 @@ package com.coveo.configuration.parameterstore;
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
 import com.amazonaws.services.simplesystemsmanagement.model.GetParameterRequest;
 import com.amazonaws.services.simplesystemsmanagement.model.ParameterNotFoundException;
-import com.coveo.configuration.parameterstore.exception.ParameterStoreParameterNotFoundRuntimeException;
-import com.coveo.configuration.parameterstore.exception.ParameterStoreRuntimeException;
+import com.coveo.configuration.parameterstore.exception.ParameterStoreParameterNotFoundError;
+import com.coveo.configuration.parameterstore.exception.ParameterStoreError;
 
 public class ParameterStoreSource
 {
@@ -25,10 +25,10 @@ public class ParameterStoreSource
                             .getValue();
         } catch (ParameterNotFoundException e) {
             if (haltBoot) {
-                throw new ParameterStoreParameterNotFoundRuntimeException(propertyName, e);
+                throw new ParameterStoreParameterNotFoundError(propertyName, e);
             }
         } catch (Exception e) {
-            throw new ParameterStoreRuntimeException(propertyName, e);
+            throw new ParameterStoreError(propertyName, e);
         }
         return null;
     }

--- a/src/main/java/com/coveo/configuration/parameterstore/exception/ParameterStoreError.java
+++ b/src/main/java/com/coveo/configuration/parameterstore/exception/ParameterStoreError.java
@@ -1,10 +1,10 @@
 package com.coveo.configuration.parameterstore.exception;
 
-public class ParameterStoreRuntimeException extends RuntimeException
+public class ParameterStoreError extends Error
 {
     private static final long serialVersionUID = 1L;
 
-    public ParameterStoreRuntimeException(String propertyName, Exception e)
+    public ParameterStoreError(String propertyName, Exception e)
     {
         super(String.format("Accessing Parameter Store for parameter '%s' failed.", propertyName), e);
     }

--- a/src/main/java/com/coveo/configuration/parameterstore/exception/ParameterStoreParameterNotFoundError.java
+++ b/src/main/java/com/coveo/configuration/parameterstore/exception/ParameterStoreParameterNotFoundError.java
@@ -2,11 +2,11 @@ package com.coveo.configuration.parameterstore.exception;
 
 import com.coveo.configuration.parameterstore.ParameterStorePropertySource;
 
-public class ParameterStoreParameterNotFoundRuntimeException extends RuntimeException
+public class ParameterStoreParameterNotFoundError extends Error
 {
     private static final long serialVersionUID = 1L;
 
-    public ParameterStoreParameterNotFoundRuntimeException(String propertyName, Exception e)
+    public ParameterStoreParameterNotFoundError(String propertyName, Exception e)
     {
         super(String.format("Properties prefixed with a '%s' are reserved for the AWS Parameter Store. "
                 + "The property '%s' was not found in it. "

--- a/src/test/java/com/coveo/configuration/parameterstore/ParameterStoreSourceTest.java
+++ b/src/test/java/com/coveo/configuration/parameterstore/ParameterStoreSourceTest.java
@@ -15,8 +15,8 @@ import com.amazonaws.services.simplesystemsmanagement.model.GetParameterRequest;
 import com.amazonaws.services.simplesystemsmanagement.model.GetParameterResult;
 import com.amazonaws.services.simplesystemsmanagement.model.Parameter;
 import com.amazonaws.services.simplesystemsmanagement.model.ParameterNotFoundException;
-import com.coveo.configuration.parameterstore.exception.ParameterStoreParameterNotFoundRuntimeException;
-import com.coveo.configuration.parameterstore.exception.ParameterStoreRuntimeException;
+import com.coveo.configuration.parameterstore.exception.ParameterStoreError;
+import com.coveo.configuration.parameterstore.exception.ParameterStoreParameterNotFoundError;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ParameterStoreSourceTest
@@ -57,7 +57,7 @@ public class ParameterStoreSourceTest
         assertThat(value, is(nullValue()));
     }
 
-    @Test(expected = ParameterStoreRuntimeException.class)
+    @Test(expected = ParameterStoreError.class)
     public void shouldThrowOnUnexpectedExceptionAccessingParameterStore()
     {
         when(ssmClientMock.getParameter(getParameterRequest(VALID_PROPERTY_NAME))).thenThrow(new RuntimeException());
@@ -65,7 +65,7 @@ public class ParameterStoreSourceTest
         parameterStoreSource.getProperty(VALID_PROPERTY_NAME);
     }
 
-    @Test(expected = ParameterStoreParameterNotFoundRuntimeException.class)
+    @Test(expected = ParameterStoreParameterNotFoundError.class)
     public void shouldThrowOnGetPropertyWhenNotFoundAndHaltBootIsTrue()
     {
         when(ssmClientMock.getParameter(getParameterRequest(INVALID_PROPERTY_NAME))).thenThrow(new ParameterNotFoundException(""));


### PR DESCRIPTION
 Use errors rather than exceptions, as runtime exceptions may be swallowed during initialization.